### PR TITLE
main: fix spelling

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,11 +77,11 @@ for i in range(opt.max_epoch):
         optimizer.step()
         if epoch% 100==0:
             if  torch.cuda.is_available():
-                print("%d ieration %d epoch with loss : %.5f in %.4f seconds" % (i,epoch,loss.cpu().data.numpy()[0],time.time()-start))
+                print("%d iteration %d epoch with loss : %.5f in %.4f seconds" % (i,epoch,loss.cpu().data.numpy()[0],time.time()-start))
             else:
-                print("%d ieration %d epoch with loss : %.5f in %.4f seconds" % (i,epoch,loss.data.numpy()[0],time.time()-start))
+                print("%d iteration %d epoch with loss : %.5f in %.4f seconds" % (i,epoch,loss.data.numpy()[0],time.time()-start))
  
     percision=utils.evaluation(model,test_iter,from_torchtext)
-    print("%d ieration with percision %.4f" % (i,percision))
+    print("%d iteration with percision %.4f" % (i,percision))
 
 


### PR DESCRIPTION
Hi,

this PR fixes a minor spelling mistake in `main.py`